### PR TITLE
Fix dependencies: restore install-jdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 avro==1.11.3
 avrotize==2.6.0
 fastavro==1.9.7
+install-jdk==1.1.0


### PR DESCRIPTION
Was a little overzealous cleaning up extra (transitive) dependencies in requirements.txt and broke toolchain installer on fresh system. This fixes that.